### PR TITLE
fix: use mcp-remote proxy for aws-knowledge-mcp-server to avoid HTTP transport timeout

### DIFF
--- a/mcps/aws-knowledge-mcp-server.json
+++ b/mcps/aws-knowledge-mcp-server.json
@@ -1,8 +1,8 @@
 {
     "mcpServers": {
         "aws-knowledge-mcp-server": {
-            "url": "https://knowledge-mcp.global.api.aws",
-            "type": "http",
+            "command": "npx",
+            "args": ["mcp-remote", "https://knowledge-mcp.global.api.aws"],
             "autoApprove": true
         }
     }


### PR DESCRIPTION
## Summary

- `"type": "http"` の HTTP transport を `npx mcp-remote` 経由（stdio）に変更
- WSL2 など非インタラクティブ環境での接続タイムアウト（30秒）を修正
- 4つのプラグイン（document-reviewer, tech-docs-searcher, terraform-code-reviewer, aws-cost-analyst）が共有する `mcps/aws-knowledge-mcp-server.json` を1ファイル修正するだけで全プラグインに反映

Closes #1

## 変更内容

```diff
-    "url": "https://knowledge-mcp.global.api.aws",
-    "type": "http",
+    "command": "npx",
+    "args": ["mcp-remote", "https://knowledge-mcp.global.api.aws"],
```

## Test plan

- [ ] Claude Code を再起動し、`/mcp` コマンドで `plugin:*:aws-knowledge-mcp-server` の接続ステータスが connected になることを確認
- [ ] WSL2 Linux 環境で接続タイムアウトが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)