### PR TITLE
Fix MCP server configs to align with official recommendations

### DIFF
--- a/aws-cost-analyst/mcps/aws-cost-explorer-mcp-server.json
+++ b/aws-cost-analyst/mcps/aws-cost-explorer-mcp-server.json
@@ -5,7 +5,8 @@
 			"args": ["awslabs.cost-explorer-mcp-server@latest"],
 			"env": {
 			"FASTMCP_LOG_LEVEL": "ERROR",
-			"AWS_PROFILE": "${AWS_PROFILE:-default}"
+			"AWS_PROFILE": "${AWS_PROFILE:-default}",
+			"AWS_REGION": "${AWS_REGION:-us-east-1}"
 			},
 			"disabled": false,
 			"autoApprove": []

--- a/terraform-code-reviewer/mcps/aws-knowledge-mcp-server.json
+++ b/terraform-code-reviewer/mcps/aws-knowledge-mcp-server.json
@@ -1,8 +1,8 @@
 {
     "mcpServers": {
         "aws-knowledge-mcp-server": {
-            "command": "npx",
-            "args": ["mcp-remote", "https://knowledge-mcp.global.api.aws"],
+            "url": "https://knowledge-mcp.global.api.aws",
+            "type": "http",
             "autoApprove": true
         }
     }


### PR DESCRIPTION
## Summary

- terraform-code-reviewer: change aws-knowledge-mcp-server from `npx mcp-remote` to direct HTTP transport, matching the official recommendation and other plugins
- aws-cost-analyst: add missing `AWS_REGION` env var to cost-explorer-mcp-server

## Context

The `npx mcp-remote` workaround (#2) is no longer needed since `document-reviewer` and `tech-docs-searcher` operate successfully with direct HTTP. The [official docs](https://awslabs.github.io/mcp/servers/aws-knowledge-mcp-server) recommend `url` + `type: "http"` as the primary method.

The `AWS_REGION` was present in `aws-pricing-mcp-server.json` but missing from `aws-cost-explorer-mcp-server.json`, inconsistent with the [official README](https://github.com/awslabs/mcp/tree/main/src/cost-explorer-mcp-server).

## Test plan

- [ ] Restart Claude Code and verify `/mcp` dialog shows no errors
- [ ] Confirm `terraform-code-reviewer` agent can access AWS Knowledge MCP tools
- [ ] Confirm `aws-cost-analyst` agent functions correctly with cost explorer

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)