### PR TITLE
fix: migrate aws-cost-explorer MCP server to billing-cost-management

### DIFF
--- a/aws-cost-analyst/mcps/aws-cost-explorer-mcp-server.json
+++ b/aws-cost-analyst/mcps/aws-cost-explorer-mcp-server.json
@@ -2,7 +2,7 @@
 	"mcpServers": {
 		"aws-cost-explorer-mcp-server": {
 			"command": "uvx",
-			"args": ["awslabs.cost-explorer-mcp-server@latest"],
+			"args": ["awslabs.billing-cost-management-mcp-server@latest"],
 			"env": {
 			"FASTMCP_LOG_LEVEL": "ERROR",
 			"AWS_PROFILE": "${AWS_PROFILE:-default}",


### PR DESCRIPTION
## Summary

- `awslabs.cost-explorer-mcp-server` が PyPI から yanked され、`uvx` での起動に失敗していた
- 後継パッケージ `awslabs.billing-cost-management-mcp-server` に移行

## Test plan

- [ ] `/reload-plugins` 後に `plugin:aws-cost-analyst:aws-cost-explorer-mcp-server` が connected になることを確認
- [ ] `/mcp` コマンドで `aws-cost-explorer-mcp-server` が正常に表示されることを確認

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)