### PR TITLE
fix: bump aws-cost-analyst to 0.0.5 and rename MCP server config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,7 +57,7 @@
       "name": "aws-cost-analyst",
       "source": "./aws-cost-analyst",
       "description": "AWS cost analysis, investigation, and cost optimization.",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "author": {
         "name": "@revsystem",
@@ -70,7 +70,7 @@
         "./agents/aws-cost-analyst.md"
       ],
       "mcpServers": [
-        "./mcps/aws-cost-explorer-mcp-server.json",
+        "./mcps/aws-billing-cost-management-mcp-server.json",
         "./mcps/aws-pricing-mcp-server.json"
       ]
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ npx markdownlint-cli "**/*.md" --ignore node_modules
 |-----------|------|--------|-----|
 | `document-reviewer` | agents + command | inherit | aws-shared-mcps |
 | `terraform-code-reviewer` | agent + command | inherit | 固有 (aws-terraform-mcp-server) |
-| `aws-cost-analyst` | agent のみ | sonnet | 固有 (cost-explorer, pricing) |
+| `aws-cost-analyst` | agent のみ | sonnet | 固有 (billing-cost-management, pricing) |
 | `tech-docs-searcher` | agent のみ | sonnet | aws-shared-mcps, context7 |
 | `aws-shared-mcps` | MCP のみ | - | aws-documentation, aws-knowledge |
 

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ cd claude-code-plugins
 
 前述の、Githubマーケットプレイスを追加する場合の手順を参照してください。
 
-### AWS_PROFILE の設定（aws-cost-explorer / aws-pricing MCPサーバー）
+### AWS_PROFILE の設定（aws-billing-cost-management / aws-pricing MCPサーバー）
 
-AWS Cost Explorer MCPサーバーと AWS Pricing MCPサーバーは AWS API にアクセスするため、`AWS_PROFILE` 環境変数の設定が必要です。
+AWS Billing Cost Management MCPサーバーと AWS Pricing MCPサーバーは AWS API にアクセスするため、`AWS_PROFILE` 環境変数の設定が必要です。
 
 MCPサーバー設定ファイルは `${AWS_PROFILE:-default}` 構文を使用しており、シェル環境の `AWS_PROFILE` を自動的に参照します。未設定の場合は AWS CLI の `default` プロファイルが使用されます。
 
@@ -174,7 +174,7 @@ export AWS_PROFILE=your-aws-profile
 
 ```text
 ~/.claude/plugins/marketplaces/document-and-code-reviewer/mcps/
-├── aws-cost-explorer-mcp-server.json
+├── aws-billing-cost-management-mcp-server.json
 └── aws-pricing-mcp-server.json
 ```
 
@@ -382,8 +382,8 @@ claude-code-plugins/
 │   ├── agents/
 │   │   └── aws-cost-analyst.md                # AWSコスト分析エージェント
 │   └── mcps/
-│       ├── aws-cost-explorer-mcp-server.json  # AWS Cost Explorer MCP
-│       └── aws-pricing-mcp-server.json        # AWS Pricing MCP
+│       ├── aws-billing-cost-management-mcp-server.json  # AWS Billing Cost Management MCP
+│       └── aws-pricing-mcp-server.json                  # AWS Pricing MCP
 └── tech-docs-searcher/                    # 技術ドキュメント検索プラグイン
     ├── agents/
     │   └── tech-docs-searcher.md              # 技術ドキュメント検索エージェント

--- a/aws-cost-analyst/mcps/aws-billing-cost-management-mcp-server.json
+++ b/aws-cost-analyst/mcps/aws-billing-cost-management-mcp-server.json
@@ -1,6 +1,6 @@
 {
 	"mcpServers": {
-		"aws-cost-explorer-mcp-server": {
+		"aws-billing-cost-management-mcp-server": {
 			"command": "uvx",
 			"args": ["awslabs.billing-cost-management-mcp-server@latest"],
 			"env": {


### PR DESCRIPTION
## Summary

- `aws-cost-explorer-mcp-server.json` を `aws-billing-cost-management-mcp-server.json` にリネーム（MCP キー名も同様に更新）
- `marketplace.json` の MCP 参照パスを新ファイル名に更新
- `aws-cost-analyst` バージョンを `0.0.4` → `0.0.5` に上げてプラグインキャッシュを無効化

## Background

PR #20 で yanked パッケージを修正したが、バージョン番号を上げなかったため Claude Code のキャッシュ（`cache/.../0.0.4/`）が更新されず `/reload-plugins` 後も旧設定のまま起動失敗が続いていた。

## Test plan

- [x] マージ後に `/reload-plugins` を実行
- [x] `plugin:aws-cost-analyst:aws-billing-cost-management-mcp-server` が connected になることを確認

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)