### PR TITLE
docs(claude-md): fix stale MCP column for document-reviewer and terraform-code-reviewer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ npx markdownlint-cli "**/*.md" --ignore node_modules
 
 | プラグイン | 種別 | モデル | MCP |
 |-----------|------|--------|-----|
-| `document-reviewer` | agents + command | inherit | 固有 (aws-documentation, aws-knowledge) |
-| `terraform-code-reviewer` | agent + command | sonnet | 固有 (aws-documentation, aws-knowledge) |
+| `document-reviewer` | agents + command | inherit | 固有 (aws-knowledge) |
+| `terraform-code-reviewer` | agent + command | sonnet | 固有 (aws-knowledge) |
 | `aws-cost-analyst` | agent のみ | sonnet | 固有 (billing-cost-management, pricing) |
 
 ### ディレクトリ構造の規約


### PR DESCRIPTION
## Summary
- The `プラグイン一覧` table's MCP column for `document-reviewer` and `terraform-code-reviewer` still said `固有 (aws-documentation, aws-knowledge)`, left over from before #29/#30 removed `aws-documentation-mcp-server` from both plugins
- The earlier CLAUDE.md sync (`a51e063`, part of #31) only removed the `tech-docs-searcher` row and the stale `aws-shared-mcps` references — it predated #29/#30 merging, so it couldn't reflect their MCP change
- Both plugins now bundle only `aws-knowledge-mcp-server.json` (verified against `document-reviewer/mcps/` and `terraform-code-reviewer/mcps/`), so the column is corrected to `固有 (aws-knowledge)`

## Test plan
- [x] `npx markdownlint-cli "**/*.md" --ignore node_modules` passes with no errors

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSoUTSbwmcaLn5uA2K7A3W