### PR TITLE
docs(changelog): add missing link definitions for v0.0.7-v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - aws-documentation-mcp-server for official AWS documentation access
 - Initial project structure and documentation
 
+[0.0.10]: https://github.com/revsystem/claude-code-plugins/compare/v0.0.9...v0.0.10
+[0.0.9]: https://github.com/revsystem/claude-code-plugins/compare/v0.0.8...v0.0.9
+[0.0.8]: https://github.com/revsystem/claude-code-plugins/compare/v0.0.7...v0.0.8
+[0.0.7]: https://github.com/revsystem/claude-code-plugins/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/revsystem/claude-code-plugins/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/revsystem/claude-code-plugins/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/revsystem/claude-code-plugins/compare/v0.0.3...v0.0.4


### PR DESCRIPTION
## Summary
- `CHANGELOG.md`'s version headings use reference-link syntax (`[0.0.X]`), but the link definitions at the bottom of the file stopped at `[0.0.6]`
- Adds the four missing compare-link definitions for `[0.0.7]` through `[0.0.10]`, following the existing pattern
- Companion to the newly created tags/releases for v0.0.1-v0.0.10 (see #29, #30, #31, #35)

## Test plan
- [x] `npx markdownlint-cli "**/*.md" --ignore node_modules` passes with no errors

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSoUTSbwmcaLn5uA2K7A3W